### PR TITLE
fix add item off screen from nothing will show blank until item size greater than keep size issue.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,6 @@ const VirtualDragList = Vue.component('virtual-drag-list', {
     return {
       list: [],
       start: 0,
-      timer: null,
       range: { start: 0, end: 0, front: 0, behind: 0 },
       virtual: null,
       sortable: null,
@@ -261,12 +260,7 @@ const VirtualDragList = Vue.component('virtual-drag-list', {
       this.list = this.dataSource;
       this._updateUniqueKeys();
 
-      if (this.virtual.sizes.size) {
-        this._updateRange(oldList, this.list);
-      } else {
-        clearTimeout(this.timer);
-        this.timer = setTimeout(() => this.virtual.updateRange(), 17);
-      }
+      this._updateRange(oldList, this.list);
 
       if (!this.sortable) {
         this.$nextTick(() => this._initSortable());


### PR DESCRIPTION
Description:
If we created a list with no items and add items later, items add out side of visible area of the scroll div is not visible until list size is greater than the `keep` size.

Steps to produce:
See demo project here: https://github.com/imvenj/drag-list-demo
1. Run the demo project;
2. Demo project's `keep` is set to `20`, resize the browser window to make sure the scroll area can only show less then 20 items;
3. Click "Add Item" button several times, until the scroll bar shows. e.g. if visible area can show 10 list items, please click about 15 times.
4. Scroll down the list.

Expect Result:
The list out side of visible area shows.

Actual Result:
Only empty space shows.

Other Notes:
1. Items invisible will not show until you add up to 20 or more items to the list and scroll the list.
2. If we initialize the project with more than one item and add more items later, everything will be OK.

Possible fix:
See pull request. The timer seems reset the update range. When add item, the update range will be set to (0, visibleItemSize). But this lead to invisible items will not be updated until total items size is more than keep, and scrolls to end reset the update range again to (first visible index, first visible index + keep). If no timer is set, the update range will always be (0, keep-1), so items outside visible areas are also been updated. I don't know the timer is necessary in other conditions, remove the timer seems to fix the issue.

Please verify if this is the correct fix. Thank you.
